### PR TITLE
FINALLY! No need to use new_curse, Makefile has two new options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,35 @@
-DEFINES =	-DSYS5  -DNCURSE -DBSD_SELECT 
+DEFINES =	-DSYS5 -DBSD_SELECT 
 
-CFLAGS =	-DHAS_UNISTD  -DHAS_STDLIB -DHAS_CTYPE -DHAS_SYS_IOCTL -DHAS_SYS_WAIT -DHAS_NCURSES -DHAS_UNISTD -DHAS_STDARG -DHAS_STDLIB -DHAS_SYS_WAIT -Ofast -march=native -mtune=native -flto -fcommon -s   -DSLCT_HDR 
+CFLAGS =	-DHAS_UNISTD  -DHAS_STDLIB -DHAS_CTYPE -DHAS_SYS_IOCTL -DHAS_SYS_WAIT -DHAS_NCURSES -DHAS_UNISTD -DHAS_STDARG -DHAS_STDLIB -DHAS_SYS_WAIT -Ofast -march=native -mtune=native -flto -fcommon -s -DSLCT_HDR 
 
-main :	curses
+main :	ncurses
 
-install : curses 
+install : main 
 	@./install-sh
 
 uninstall : clean
 	@./uninstall-sh
 
 clean :
-	rm -f *.o aee xae xae_dir/*.o
+	rm -f *.o aee ane xae_dir/*.o
 
-all :	curses
+all :	ncurses new_curse
 
 CC = clang
 
-OBJS = aee.o control.o new_curse.o format.o localize.o srch_rep.o delete.o mark.o motion.o keys.o help.o windows.o journal.o file.o
+OBJS = aee.o control.o format.o localize.o srch_rep.o delete.o mark.o motion.o keys.o help.o windows.o journal.o file.o
 
 .c.o: 
 	$(CC) $(DEFINES) -c $*.c $(CFLAGS)
 
+ncurses :	$(OBJS)
+	$(CC) -o aee $(OBJS) $(CFLAGS) $(LDFLAGS) -DHAS_NCURSES -lncursesw 
+
 curses :	$(OBJS)
-	$(CC) -o aee $(OBJS) $(CFLAGS) $(LDFLAGS) -lncurses 
+	$(CC) -o aee $(OBJS) $(CFLAGS) $(LDFLAGS) -DCURSES -lncursesw
+
+new_curse :	$(OBJS) $(new_curse.o)
+	$(CC) -o aee $(OBJS) -DNCURSE new_curse.o $(CFLAGS) $(LDFLAGS)
 
 aee.o: aee.c aee.h new_curse.h aee_version.h
 control.o: control.c new_curse.h aee.h  

--- a/aee.h
+++ b/aee.h
@@ -39,23 +39,16 @@
 
 extern int eightbit;		/* eight bit character flag		*/
 
-#ifndef XAE
 #ifdef NCURSE
 #include "new_curse.h"
+#elif HAS_NCURSES
+#include <ncurses.h>
 #else
 #include <curses.h>
 #endif
-#else	/* ifdef XAE	*/
-#ifdef xae11
-#include "Xcurse.h"
-#else
-#include "X10curse.h"
-#endif	/* xae11 */
-#endif	/* XAE */
 
 extern struct stat buf;
 
-#ifndef XAE
 #ifdef SYS5			/* System V specific tty operations	*/
 extern struct termio old_term;
 extern struct termio new_term;
@@ -64,7 +57,6 @@ extern struct termio new_term;
 extern struct sgttyb old_term;
 extern struct sgttyb new_term;
 #endif
-#endif	/* XAE */
 
 #ifndef SIGCHLD
 #define SIGCHLD SIGCLD

--- a/install-sh
+++ b/install-sh
@@ -29,6 +29,11 @@ then
 	install  aee     /usr/local/bin
 fi
 
+if [ -x ane ]
+then
+	install  ane     /usr/local/bin
+fi
+
 install  aee.1   /usr/local/man/man1
 install  help.ae /usr/local/aee
 

--- a/new_curse.c
+++ b/new_curse.c
@@ -979,6 +979,7 @@ printf("starting initscr \n");fflush(stdout);
 	if ((String_table[cm__] == NULL) || (Booleans[hc__]))
 	{
 		fprintf(stderr, "sorry, unable to use this terminal type for screen editing\nplease try properly setting the TERM variable\n");
+		String_table[cm__] = "\0";
 		exit(0);
 	}
 	Key_Get();


### PR DESCRIPTION
figured out why AMDmi3's build of aee didn't fail on an xterm-256color TERM variable. Fixed my variant of aee to use that, there's also two new makefile options! new_curse and curses! curses uses system curses instead of ncurses and new_curse to use that software. Modify the Makefile with your choice to try each. (change the main option.)